### PR TITLE
fix `typemXX(Float64)` to `realmXX(Float64)`

### DIFF
--- a/lib/julializer.rb
+++ b/lib/julializer.rb
@@ -423,9 +423,9 @@ module Julializer
               when "EPSILON"
                 "eps()"
               when "MAX"
-                "typemax(Float64)"
+                "realmax(Float64)"
               when "MIN"
-                "typemin(Float64)"
+                "realmin(Float64)"
               else
                 transpile(s[1])
               end


### PR DESCRIPTION
`Float::MAX` in Ruby is equivalent to `realmax(Float64)` in Julia.
Similarly, `Float::MIN` is equivalent to `realmin(Float64)`.
With this fix, 3 "failure" is corrected ("Float constant MAX is 1.7976931348623157e+308", "Float constant MIN is 2.2250738585072014e-308", "Float#-@ negates self at Float boundaries").